### PR TITLE
refactor: change default ST domain feed type

### DIFF
--- a/lib/mihari/analyzers/securitytrails_domain_feed.rb
+++ b/lib/mihari/analyzers/securitytrails_domain_feed.rb
@@ -12,13 +12,15 @@ module Mihari
       attr_reader :description
       attr_reader :tags
 
-      def initialize(regexp, title: nil, description: nil, tags: [])
+      def initialize(regexp, type: "registered", title: nil, description: nil, tags: [])
         super()
 
         @api = ::SecurityTrails::API.new
         @_regexp = regexp
+        @type = type
 
         raise ArgumentError, "#{@_regexp} is not a valid regexp" unless regexp
+        raise ArgumentError, "#{type} is not a valid type" unless valid_type?
 
         @title = title || "SecurityTrails domain feed lookup"
         @description = description || "Regexp = /#{@_regexp}/"
@@ -30,6 +32,10 @@ module Mihari
       end
 
       private
+
+      def valid_type?
+        %w(all new registered).include? type
+      end
 
       def regexp
         @regexp ||= Regexp.compile(@_regexp)
@@ -46,7 +52,7 @@ module Mihari
       end
 
       def new_domains
-        api.feeds.domains("new")
+        api.feeds.domains type
       end
     end
   end

--- a/lib/mihari/cli.rb
+++ b/lib/mihari/cli.rb
@@ -71,6 +71,7 @@ module Mihari
     method_option :title, type: :string, desc: "title"
     method_option :description, type: :string, desc: "description"
     method_option :tags, type: :array, desc: "tags"
+    method_option :type, type: :string, default: "registered", desc: "A type of domain feed ('all', 'new' or 'registered')"
     def securitytrails_domain_feed(regexp)
       with_error_handling do
         run_analyzer Analyzers::SecurityTrailsDomainFeed, query: regexp, options: options

--- a/spec/analyzers/securitytrails_domain_feed_spec.rb
+++ b/spec/analyzers/securitytrails_domain_feed_spec.rb
@@ -18,4 +18,20 @@ RSpec.describe Mihari::Analyzers::SecurityTrailsDomainFeed do
       expect(subject.artifacts).to be_an(Array)
     end
   end
+
+  context "when given an invalid regex" do
+    describe "#initialize" do
+      it do
+        expect { described_class.new(nil) }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  context "when given an invalid type" do
+    describe "#initialize" do
+      it do
+        expect { described_class.new(regexp, tags: tags, type: "foo bar") }.to raise_error(ArgumentError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Change default ST domain feed type from “new” to “registered”