### PR TITLE
fix: fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Commands:
   mihari status                               # Show the current configuration status
   mihari urlscan [QUERY]                      # urlscan lookup by a given query
   mihari virustotal [IP|DOMAIN]               # VirusTotal resolutions lookup by a given ip or domain
-  mihari zoommeye [QUERY]                     # ZoomEye lookup by a given query
+  mihari zoomeye [QUERY]                     # ZoomEye lookup by a given query
 
 ```
 

--- a/lib/mihari/cli.rb
+++ b/lib/mihari/cli.rb
@@ -120,7 +120,7 @@ module Mihari
       end
     end
 
-    desc "zoommeye [QUERY]", "ZoomEye lookup by a given query"
+    desc "zoomeye [QUERY]", "ZoomEye lookup by a given query"
     method_option :title, type: :string, desc: "title"
     method_option :description, type: :string, desc: "description"
     method_option :tags, type: :array, desc: "tags"


### PR DESCRIPTION
`zoomeye` to `zoomeye`