### PR TITLE
refactor: rename SQLite to Database

### DIFF
--- a/lib/mihari.rb
+++ b/lib/mihari.rb
@@ -71,9 +71,9 @@ require "mihari/notifiers/slack"
 require "mihari/notifiers/exception_notifier"
 
 require "mihari/emitters/base"
+require "mihari/emitters/database"
 require "mihari/emitters/misp"
 require "mihari/emitters/slack"
-require "mihari/emitters/sqlite"
 require "mihari/emitters/stdout"
 require "mihari/emitters/the_hive"
 

--- a/lib/mihari/emitters/database.rb
+++ b/lib/mihari/emitters/database.rb
@@ -2,7 +2,7 @@
 
 module Mihari
   module Emitters
-    class SQLite < Base
+    class Database < Base
       def valid?
         true
       end

--- a/spec/emitters/database_spec.rb
+++ b/spec/emitters/database_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Mihari::Emitters::SQLite, :vcr do
+RSpec.describe Mihari::Emitters::Database do
   subject { described_class.new }
 
   describe "#emit" do


### PR DESCRIPTION
Rename SQLite to Database because now it supports SQLite and also PostgreSQL