### PR TITLE
chore: set exit_on_failure? in CIL

### DIFF
--- a/lib/mihari/cli.rb
+++ b/lib/mihari/cli.rb
@@ -7,6 +7,10 @@ module Mihari
   class CLI < Thor
     class_option :config, type: :string, desc: "path to config file"
 
+    def self.exit_on_failure?
+      true
+    end
+
     desc "censys [QUERY]", "Censys IPv4 search by a query"
     method_option :title, type: :string, desc: "title"
     method_option :description, type: :string, desc: "description"

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe Mihari::CLI do
 
   before { allow(mock).to receive(:run) }
 
+  describe ".exit_on_failure?" do
+    it do
+      expect(subject.exit_on_failure?).to eq(true)
+    end
+  end
+
   describe "#censys" do
     before { allow(Mihari::Analyzers::Censys).to receive(:new).and_return(mock) }
 


### PR DESCRIPTION
Set .exit_on_failure? in CLI to silence deprecations warning