### PR TITLE
chore: ignore JSON::ParserError

### DIFF
--- a/lib/mihari/analyzers/shodan.rb
+++ b/lib/mihari/analyzers/shodan.rb
@@ -56,6 +56,10 @@ module Mihari
 
           responses << res
           break if res["total"].to_i <= page * PAGE_SIZE
+        rescue JSON::ParserError
+          # ignore JSON::ParserError
+          # ref. https://github.com/ninoseki/mihari/issues/197
+          next
         end
         responses
       end


### PR DESCRIPTION
Ignore JSON::ParserError when iterating Shodan search results