### PR TITLE
refactor: replace otx-ruby

### DIFF
--- a/lib/mihari/analyzers/clients/otx.rb
+++ b/lib/mihari/analyzers/clients/otx.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Mihari
+  module Analyzers
+    module Clients
+      class OTX
+        attr_reader :api_key
+
+        def initialize(api_key)
+          @api_key = api_key
+        end
+
+        def query_by_ip(ip)
+          get "https://otx.alienvault.com/api/v1/indicators/IPv4/#{ip}/passive_dns"
+        end
+
+        def query_by_domain(domain)
+          get "https://otx.alienvault.com/api/v1/indicators/domain/#{domain}/passive_dns"
+        end
+
+        private
+
+        def headers
+          { "x-otx-api-key": api_key }
+        end
+
+        def get(url)
+          res = HTTP.get(url, headers: headers)
+          JSON.parse(res.body.to_s)
+        rescue HTTPError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/mihari.gemspec
+++ b/mihari.gemspec
@@ -76,7 +76,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-ping", "2.0.8"
   spec.add_dependency "normalize_country", "0.3.2"
   spec.add_dependency "onyphe", "2.0.0"
-  spec.add_dependency "otx_ruby", "0.9.9"
   spec.add_dependency "parallel", "1.22.1"
   spec.add_dependency "passive_circl", "0.1.0"
   spec.add_dependency "passivetotalx", "0.1.1"

--- a/spec/fixtures/vcr_cassettes/Mihari_Analyzers_OTX/when_given_a_domain/_artifacts/1_2_1_1.yml
+++ b/spec/fixtures/vcr_cassettes/Mihari_Analyzers_OTX/when_given_a_domain/_artifacts/1_2_1_1.yml
@@ -7,14 +7,16 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      User-Agent:
-      - Faraday v0.17.3
-      X-Otx-Api-Key:
-      - "<OTX_API_KEY>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - otx.alienvault.com
+      X-Otx-Api-Key:
+      - "<OTX_API_KEY>"
   response:
     status:
       code: 200
@@ -23,47 +25,50 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '316'
+      - '367'
       Connection:
       - keep-alive
+      Date:
+      - Sat, 18 Jun 2022 01:05:17 GMT
+      Server:
+      - gunicorn
       Cache-Control:
       - max-age=600
-      Date:
-      - Sat, 01 Aug 2020 00:14:53 GMT
-      Server:
-      - nginx
-      Set-Cookie:
-      - authkeys="api_key:<OTX_API_KEY>:1k1fAr:12EHotfFpg1jtuF5QfRAcUVGLyY"; expires=Sat,
-        01-Aug-2020 03:14:53 GMT; Max-Age=10800; Path=/
       X-Frame-Options:
       - SAMEORIGIN
+      X-Remote-User-Name:
+      - niseki
       X-Otx-Active:
       - '1'
+      Access-Control-Allow-Origin:
+      - "*"
       Vary:
       - Accept-Encoding
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 efb99d3a822380f07a607f1aad7468f7.cloudfront.net (CloudFront)
+      - 1.1 eb653d436fde5f3e890eb3528ceda15e.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
-      - NRT57-C4
+      - NRT20-C4
       X-Amz-Cf-Id:
-      - nWxlml669JSjyTON5lzIvIaT3CCT0W9jpDE2DXG5XERFlsdlbcriTw==
+      - Ggx-knEOzwbAyc94Gz_7ToyQj-KZ3_YujGZD0siosidyE1vu2n5Plg==
     body:
       encoding: ASCII-8BIT
-      string: '{"passive_dns": [{"flag_url": "assets/images/ro.png", "record_type":
-        "A", "last": "2019-09-04T18:16:07+00:00", "flag_title": "Romania", "address":
-        "193.148.69.37", "indicator_link": "/indicator/domain/jppost-tu.top", "hostname":
-        "jppost-tu.top", "asset_type": "domain", "first": "2019-09-04T05:32:29+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-09-02T01:30:07+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-tu.top",
-        "hostname": "jppost-tu.top", "asset_type": "domain", "first": "2019-09-02T01:30:07+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-08-31T07:14:45+00:00",
-        "flag_title": "Romania", "address": "193.148.69.230", "indicator_link": "/indicator/domain/jppost-tu.top",
-        "hostname": "jppost-tu.top", "asset_type": "domain", "first": "2019-08-31T07:14:45+00:00"},
-        {"flag_url": "assets/images/fr.png", "record_type": "A", "last": "2019-07-02T14:17:10+00:00",
-        "flag_title": "France", "address": "51.68.251.30", "indicator_link": "/indicator/domain/jppost-tu.top",
-        "hostname": "jppost-tu.top", "asset_type": "domain", "first": "2019-07-02T14:17:10+00:00"}],
+      string: '{"passive_dns": [{"address": "193.148.69.37", "first": "2019-09-04T05:32:29",
+        "last": "2019-09-04T18:16:07", "hostname": "jppost-tu.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-tu.top", "flag_url": "assets/images/flags/de.png",
+        "flag_title": "Germany", "asset_type": "domain", "asn": "ASNone "}, {"address":
+        "89.35.39.84", "first": "2019-09-02T01:30:07", "last": "2019-09-02T01:30:07",
+        "hostname": "jppost-tu.top", "record_type": "A", "indicator_link": "/indicator/domain/jppost-tu.top",
+        "flag_url": "assets/images/flags/ro.png", "flag_title": "Romania", "asset_type":
+        "domain", "asn": "AS20473 the constant company  llc"}, {"address": "193.148.69.230",
+        "first": "2019-08-31T07:14:45", "last": "2019-08-31T07:14:45", "hostname":
+        "jppost-tu.top", "record_type": "A", "indicator_link": "/indicator/domain/jppost-tu.top",
+        "flag_url": "assets/images/flags/de.png", "flag_title": "Germany", "asset_type":
+        "domain", "asn": "ASNone "}, {"address": "51.68.251.30", "first": "2019-07-02T14:17:10",
+        "last": "2019-07-02T14:17:10", "hostname": "jppost-tu.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-tu.top", "flag_url": "assets/images/flags/fr.png",
+        "flag_title": "France", "asset_type": "domain", "asn": "AS16276 ovh sas"}],
         "count": 4}'
-  recorded_at: Sat, 01 Aug 2020 00:14:53 GMT
-recorded_with: VCR 6.0.0
+  recorded_at: Sat, 18 Jun 2022 01:05:15 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/Mihari_Analyzers_OTX/when_given_an_ipv4/_artifacts/1_1_1_1.yml
+++ b/spec/fixtures/vcr_cassettes/Mihari_Analyzers_OTX/when_given_an_ipv4/_artifacts/1_1_1_1.yml
@@ -7,14 +7,16 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      User-Agent:
-      - Faraday v0.17.3
-      X-Otx-Api-Key:
-      - "<OTX_API_KEY>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
       - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - otx.alienvault.com
+      X-Otx-Api-Key:
+      - "<OTX_API_KEY>"
   response:
     status:
       code: 200
@@ -23,137 +25,171 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '776'
+      - '799'
       Connection:
       - keep-alive
+      Date:
+      - Sat, 18 Jun 2022 01:05:17 GMT
+      Server:
+      - gunicorn
       Cache-Control:
       - max-age=600
-      Date:
-      - Sat, 01 Aug 2020 00:14:53 GMT
-      Server:
-      - nginx
-      Set-Cookie:
-      - authkeys="api_key:<OTX_API_KEY>:1k1fAr:12EHotfFpg1jtuF5QfRAcUVGLyY"; expires=Sat,
-        01-Aug-2020 03:14:53 GMT; Max-Age=10800; Path=/
       X-Frame-Options:
       - SAMEORIGIN
+      X-Remote-User-Name:
+      - niseki
       X-Otx-Active:
       - '1'
+      Access-Control-Allow-Origin:
+      - "*"
       Vary:
       - Accept-Encoding
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 ece495703bac6f634e6e16b4037affae.cloudfront.net (CloudFront)
+      - 1.1 315957e067430cc1a4500ab52fbcbc32.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
-      - NRT57-C4
+      - NRT20-C4
       X-Amz-Cf-Id:
-      - vqmqK0Bl-0fyjT13kmWCUOMQ4ahGUZh_qxS7Q3G2bQlr8TkV58hBmg==
+      - x75pG0_1z3fsPtxuLBhRECqZ17RG1yIRyU8hSwBb3Q2p2jdbCpw4cQ==
     body:
       encoding: ASCII-8BIT
-      string: '{"passive_dns": [{"flag_url": "assets/images/ro.png", "record_type":
-        "A", "last": "2019-09-02T15:09:30+00:00", "flag_title": "Romania", "address":
-        "89.35.39.84", "indicator_link": "/indicator/domain/jppost-gu.co", "hostname":
-        "jppost-gu.co", "asset_type": "domain", "first": "2019-09-02T15:09:30+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-09-02T20:18:23+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-ga.co",
-        "hostname": "jppost-ga.co", "asset_type": "domain", "first": "2019-09-02T15:09:30+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-09-02T16:14:59+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-gi.co",
-        "hostname": "jppost-gi.co", "asset_type": "domain", "first": "2019-09-02T14:53:30+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-09-02T20:00:39+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-bri.top",
-        "hostname": "jppost-bri.top", "asset_type": "domain", "first": "2019-09-02T14:50:32+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-09-02T14:51:15+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-bre.top",
-        "hostname": "jppost-bre.top", "asset_type": "domain", "first": "2019-09-02T14:49:17+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-09-02T07:43:36+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-bru.top",
-        "hostname": "jppost-bru.top", "asset_type": "domain", "first": "2019-09-02T03:52:39+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-09-02T07:43:57+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-byu.top",
-        "hostname": "jppost-byu.top", "asset_type": "domain", "first": "2019-09-02T03:52:39+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-09-02T16:23:18+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-bra.top",
-        "hostname": "jppost-bra.top", "asset_type": "domain", "first": "2019-09-02T03:52:39+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-09-02T07:43:25+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-bya.top",
-        "hostname": "jppost-bya.top", "asset_type": "domain", "first": "2019-09-02T03:52:38+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-09-02T07:43:49+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-byo.top",
-        "hostname": "jppost-byo.top", "asset_type": "domain", "first": "2019-09-02T02:33:49+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-09-02T07:44:12+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-bro.top",
-        "hostname": "jppost-bro.top", "asset_type": "domain", "first": "2019-09-02T02:33:41+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-09-02T01:30:07+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-su.top",
-        "hostname": "jppost-su.top", "asset_type": "domain", "first": "2019-09-02T01:30:07+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-09-02T01:30:07+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-hi.top",
-        "hostname": "jppost-hi.top", "asset_type": "domain", "first": "2019-09-02T01:30:07+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-09-02T01:30:07+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-tu.top",
-        "hostname": "jppost-tu.top", "asset_type": "domain", "first": "2019-09-02T01:30:07+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-08-31T15:55:41+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-bha.top",
-        "hostname": "jppost-bha.top", "asset_type": "domain", "first": "2019-08-30T14:12:40+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-08-30T14:12:35+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-bme.top",
-        "hostname": "jppost-bme.top", "asset_type": "domain", "first": "2019-08-30T14:12:35+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-08-30T14:12:41+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-bmu.top",
-        "hostname": "jppost-bmu.top", "asset_type": "domain", "first": "2019-08-30T14:12:35+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-08-30T14:12:36+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-bko.top",
-        "hostname": "jppost-bko.top", "asset_type": "domain", "first": "2019-08-30T14:12:35+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-08-30T10:22:29+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-bmo.top",
-        "hostname": "jppost-bmo.top", "asset_type": "domain", "first": "2019-08-30T01:06:17+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-08-30T01:06:13+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-bhu.top",
-        "hostname": "jppost-bhu.top", "asset_type": "domain", "first": "2019-08-30T01:06:13+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-08-30T10:22:39+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-bho.top",
-        "hostname": "jppost-bho.top", "asset_type": "domain", "first": "2019-08-30T01:06:13+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-08-30T10:22:42+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-bma.top",
-        "hostname": "jppost-bma.top", "asset_type": "domain", "first": "2019-08-30T01:06:12+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-08-29T04:02:13+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-aki.com",
-        "hostname": "jppost-aki.com", "asset_type": "domain", "first": "2019-08-29T04:02:13+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-08-29T04:02:10+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-bfu.top",
-        "hostname": "jppost-bfu.top", "asset_type": "domain", "first": "2019-08-29T04:02:10+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-08-29T04:01:54+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-pe.com",
-        "hostname": "jppost-pe.com", "asset_type": "domain", "first": "2019-08-29T04:01:54+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-08-30T01:06:14+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-bhi.top",
-        "hostname": "jppost-bhi.top", "asset_type": "domain", "first": "2019-08-29T04:01:21+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-08-30T01:06:13+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-bmi.top",
-        "hostname": "jppost-bmi.top", "asset_type": "domain", "first": "2019-08-29T04:00:14+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-09-02T01:30:07+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-bse.top",
-        "hostname": "jppost-bse.top", "asset_type": "domain", "first": "2019-08-27T19:41:32+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-08-27T19:41:31+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-bsu.top",
-        "hostname": "jppost-bsu.top", "asset_type": "domain", "first": "2019-08-27T16:06:18+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-08-27T16:06:16+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-yu.com",
-        "hostname": "jppost-yu.com", "asset_type": "domain", "first": "2019-08-27T16:06:16+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-08-27T19:41:31+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-btu.top",
-        "hostname": "jppost-btu.top", "asset_type": "domain", "first": "2019-08-27T16:06:13+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-08-27T19:41:31+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-bto.top",
-        "hostname": "jppost-bto.top", "asset_type": "domain", "first": "2019-08-27T16:06:13+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-08-27T19:41:31+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-bsa.top",
-        "hostname": "jppost-bsa.top", "asset_type": "domain", "first": "2019-08-27T16:06:12+00:00"},
-        {"flag_url": "assets/images/ro.png", "record_type": "A", "last": "2019-08-27T13:25:10+00:00",
-        "flag_title": "Romania", "address": "89.35.39.84", "indicator_link": "/indicator/domain/jppost-ahi.top",
-        "hostname": "jppost-ahi.top", "asset_type": "domain", "first": "2019-08-27T13:19:20+00:00"}],
-        "count": 34}'
-  recorded_at: Sat, 01 Aug 2020 00:14:53 GMT
-recorded_with: VCR 6.0.0
+      string: '{"passive_dns": [{"address": "89.35.39.84", "first": "2019-09-02T15:09:30",
+        "last": "2019-09-02T20:18:23", "hostname": "jppost-ga.co", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-ga.co", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-09-02T15:09:30",
+        "last": "2019-09-02T15:09:30", "hostname": "jppost-gu.co", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-gu.co", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-09-02T14:53:30",
+        "last": "2019-09-02T16:14:59", "hostname": "jppost-gi.co", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-gi.co", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-09-02T14:50:32",
+        "last": "2019-09-02T20:00:39", "hostname": "jppost-bri.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-bri.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-09-02T14:49:17",
+        "last": "2019-09-02T14:51:15", "hostname": "jppost-bre.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-bre.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-09-02T03:52:39",
+        "last": "2019-09-02T16:23:18", "hostname": "jppost-bra.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-bra.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-09-02T03:52:39",
+        "last": "2019-09-02T07:43:57", "hostname": "jppost-byu.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-byu.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-09-02T03:52:39",
+        "last": "2019-09-02T07:43:36", "hostname": "jppost-bru.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-bru.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-09-02T03:52:38",
+        "last": "2019-09-02T07:43:25", "hostname": "jppost-bya.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-bya.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-09-02T02:33:49",
+        "last": "2019-09-02T07:43:49", "hostname": "jppost-byo.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-byo.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-09-02T02:33:41",
+        "last": "2019-09-02T07:44:12", "hostname": "jppost-bro.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-bro.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-09-02T01:30:07",
+        "last": "2019-09-02T01:30:07", "hostname": "jppost-tu.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-tu.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-09-02T01:30:07",
+        "last": "2019-09-02T01:30:07", "hostname": "jppost-hi.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-hi.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-09-02T01:30:07",
+        "last": "2019-09-02T01:30:07", "hostname": "jppost-su.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-su.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-08-30T14:12:40",
+        "last": "2019-08-31T15:55:41", "hostname": "jppost-bha.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-bha.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-08-30T14:12:35",
+        "last": "2019-08-30T14:12:36", "hostname": "jppost-bko.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-bko.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-08-30T14:12:35",
+        "last": "2019-08-30T14:12:41", "hostname": "jppost-bmu.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-bmu.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-08-30T14:12:35",
+        "last": "2019-08-30T14:12:35", "hostname": "jppost-bme.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-bme.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-08-30T01:06:17",
+        "last": "2019-08-30T10:22:29", "hostname": "jppost-bmo.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-bmo.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-08-30T01:06:13",
+        "last": "2019-08-30T10:22:39", "hostname": "jppost-bho.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-bho.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-08-30T01:06:13",
+        "last": "2019-08-30T01:06:13", "hostname": "jppost-bhu.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-bhu.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-08-30T01:06:12",
+        "last": "2019-08-30T10:22:42", "hostname": "jppost-bma.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-bma.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-08-29T04:02:13",
+        "last": "2019-08-29T04:02:13", "hostname": "jppost-aki.com", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-aki.com", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-08-29T04:02:10",
+        "last": "2019-08-29T04:02:10", "hostname": "jppost-bfu.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-bfu.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-08-29T04:01:54",
+        "last": "2019-08-29T04:01:54", "hostname": "jppost-pe.com", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-pe.com", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-08-29T04:01:21",
+        "last": "2019-08-30T01:06:14", "hostname": "jppost-bhi.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-bhi.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-08-29T04:00:14",
+        "last": "2019-08-30T01:06:13", "hostname": "jppost-bmi.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-bmi.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-08-27T19:41:32",
+        "last": "2019-09-02T01:30:07", "hostname": "jppost-bse.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-bse.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-08-27T16:06:18",
+        "last": "2019-08-27T19:41:31", "hostname": "jppost-bsu.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-bsu.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-08-27T16:06:16",
+        "last": "2019-08-27T16:06:16", "hostname": "jppost-yu.com", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-yu.com", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-08-27T16:06:13",
+        "last": "2019-08-27T19:41:31", "hostname": "jppost-bto.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-bto.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-08-27T16:06:13",
+        "last": "2019-08-27T19:41:31", "hostname": "jppost-btu.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-btu.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-08-27T16:06:12",
+        "last": "2019-08-27T19:41:31", "hostname": "jppost-bsa.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-bsa.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}, {"address": "89.35.39.84", "first": "2019-08-27T13:19:20",
+        "last": "2019-08-27T13:25:10", "hostname": "jppost-ahi.top", "record_type":
+        "A", "indicator_link": "/indicator/domain/jppost-ahi.top", "flag_url": "assets/images/flags/ro.png",
+        "flag_title": "Romania", "asset_type": "domain", "asn": "AS20473 the constant
+        company  llc"}], "count": 34}'
+  recorded_at: Sat, 18 Jun 2022 01:05:15 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
Replace `otx-ruby` to fix deprecation warnings.