### PR TITLE
fix: fix NoMethodError while enriching ports

### DIFF
--- a/lib/mihari/models/port.rb
+++ b/lib/mihari/models/port.rb
@@ -14,7 +14,7 @@ module Mihari
       #
       def build_by_ip(ip)
         res = Enrichers::Shodan.query(ip)
-        return if res.nil?
+        return [] if res.nil?
 
         res.ports.map { |port| new(port: port) }
       end


### PR DESCRIPTION
Change to return `[]` if `res.nil?`.
Otherwise the following `NoMethodError` occurs when `res.nil?`.

```
2022-06-25 21:32:54.587652 E [33170:8080 error_notification.rb:14] Mihari -- Exception: NoMethodError: undefined method `each' for nil:NilClass
/Users/foo/.anyenv/envs/rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/activerecord-7.0.3/lib/active_record/associations/collection_association.rb:235:in `replace'
/Users/foo/.anyenv/envs/rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/activerecord-7.0.3/lib/active_record/associations/collection_association.rb:45:in `writer'
/Users/foo/.anyenv/envs/rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/activerecord-7.0.3/lib/active_record/associations/builder/association.rb:112:in `ports='
/Users/foo/Dev/mihari/lib/mihari/models/artifact.rb:113:in `enrich_ports'
/Users/foo/Dev/mihari/lib/mihari/models/artifact.rb:164:in `block in enrich_by_enricher'
/Users/foo/Dev/mihari/lib/mihari/models/artifact.rb:163:in `each'
/Users/foo/Dev/mihari/lib/mihari/models/artifact.rb:163:in `enrich_by_enricher'
/Users/foo/Dev/mihari/lib/mihari/analyzers/rule.rb:125:in `block (2 levels) in enriched_artifacts'
/Users/foo/Dev/mihari/lib/mihari/analyzers/rule.rb:124:in `each'
/Users/foo/Dev/mihari/lib/mihari/analyzers/rule.rb:124:in `block in enriched_artifacts'
...
```