### PR TITLE
refactor: use dry-schema's errors for error report

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,4 @@
+Style/HashSyntax:
+  EnforcedShorthandSyntax: either
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/lib/mihari/commands/validator.rb
+++ b/lib/mihari/commands/validator.rb
@@ -18,7 +18,8 @@ module Mihari
 
             begin
               rule.validate!
-              Mihari.logger.info "Valid format. The input is parsed as the following:\n#{rule.data.to_yaml}"
+              Mihari.logger.info "Valid format. The input is parsed as the following:"
+              Mihari.logger.info rule.data.to_yaml
             rescue RuleValidationError
               nil
             end

--- a/spec/structs/rule_spec.rb
+++ b/spec/structs/rule_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+RSpec.describe Mihari::Structs::Rule do
+  let(:data) do
+    {
+      description: "foo",
+      title: "foo",
+      queries: [
+        { analyzer: "shodan", query: "foo" }
+      ],
+      allowed_data_types: ["ip"]
+    }
+  end
+  let(:yaml) { data.to_yaml }
+  let(:rule) { described_class.new(data, yaml) }
+
+  describe "#errors?" do
+    it "should not have any errors" do
+      expect(rule.errors?).to eq(false)
+    end
+  end
+
+  describe "#to_analyzer" do
+    it "should return an analyzer" do
+      expect(rule.to_analyzer).to be_a Mihari::Analyzers::Rule
+    end
+  end
+end


### PR DESCRIPTION
Change to use `dry-schema`'s `errors` for the validation error reporting (in JSON format)