### PR TITLE
feat: make possible to set worker timeout

### DIFF
--- a/lib/mihari/commands/web.rb
+++ b/lib/mihari/commands/web.rb
@@ -10,16 +10,18 @@ module Mihari
           method_option :host, type: :string, default: "localhost", desc: "Port to listen on"
           method_option :threads, type: :string, default: "1:1", desc: "min:max threads to use"
           method_option :verbose, type: :boolean, default: true, desc: "Report each request"
+          method_option :worker_timeout, type: :numeric, default: 60, desc: "Worker timeout value (in seconds)"
           def web
             port = options["port"]
             host = options["host"]
             threads = options["threads"]
             verbose = options["verbose"]
+            worker_timeout = options["worker_timeout"]
 
             # set rack env as production
             ENV["RACK_ENV"] ||= "production"
 
-            Mihari::App.run!(port: port, host: host, threads: threads, verbose: verbose)
+            Mihari::App.run!(port: port, host: host, threads: threads, verbose: verbose, worker_timeout: worker_timeout)
           end
         end
       end


### PR DESCRIPTION
Make it possible to set [worker_timeout](https://www.rubydoc.info/gems/puma/Puma%2FDSL:worker_timeout) via CLI for #525.
 