### PR TITLE
refactor: refactoring rule model &entity

### DIFF
--- a/lib/mihari/entities/rule.rb
+++ b/lib/mihari/entities/rule.rb
@@ -14,6 +14,8 @@ module Mihari
 
     class Rule < Grape::Entity
       expose :id, documentation: { type: String, required: true }
+      expose :title, documentation: { type: String, required: true }
+      expose :description, documentation: { type: String, required: true }
       expose :yaml, documentation: { type: String, required: true }
       expose :created_at, documentation: { type: DateTime, required: true }, as: :createdAt
       expose :updated_at, documentation: { type: DateTime, required: true }, as: :updatedAt

--- a/lib/mihari/models/rule.rb
+++ b/lib/mihari/models/rule.rb
@@ -10,19 +10,8 @@ module Mihari
       @symbolized_data ||= data.deep_symbolize_keys
     end
 
-    #
-    # Returns a hash representative
-    #
-    # @return [Hash]
-    #
-    def to_h
-      {
-        id: id,
-        yaml: data.to_yaml,
-        data: data,
-        created_at: created_at,
-        updated_at: updated_at
-      }
+    def yaml
+      @yaml ||= data.to_yaml
     end
 
     class << self

--- a/lib/mihari/web/endpoints/rules.rb
+++ b/lib/mihari/web/endpoints/rules.rb
@@ -51,7 +51,7 @@ module Mihari
           total = Mihari::Rule.count(search_filter_with_pagenation.without_pagination)
 
           present(
-            { rules: rules.map(&:to_h),
+            { rules: rules,
               total: total,
               current_page: page,
               page_size: limit },
@@ -76,7 +76,7 @@ module Mihari
             error!({ message: "ID:#{id} is not found" }, 404)
           end
 
-          present rule.to_h, with: Entities::Rule
+          present rule, with: Entities::Rule
         end
 
         desc "Run a rule", {
@@ -144,7 +144,7 @@ module Mihari
           end
 
           status 201
-          present model.to_h, with: Entities::Rule
+          present model, with: Entities::Rule
         end
 
         desc "Update a rule", {
@@ -188,7 +188,7 @@ module Mihari
           end
 
           status 201
-          present model.to_h, with: Entities::Rule
+          present model, with: Entities::Rule
         end
 
         desc "Delete a rule", {


### PR DESCRIPTION
- Stop using `#to_h` in the Rule model
- Add title and description in the Rule entity