### PR TITLE
Renew API endpoints

### DIFF
--- a/lib/mihari/commands/web.rb
+++ b/lib/mihari/commands/web.rb
@@ -14,18 +14,11 @@ module Mihari
           method_option :hide_config_values, type: :boolean, default: false,
             desc: "Whether to hide config values or not"
           def web
-            port = options["port"]
-            host = options["host"]
-            threads = options["threads"]
-            verbose = options["verbose"]
-            worker_timeout = options["worker_timeout"]
-
             Mihari.config.hide_config_values = options["hide_config_values"]
-
             # set rack env as production
             ENV["RACK_ENV"] ||= "production"
-
-            Mihari::App.run!(port: port, host: host, threads: threads, verbose: verbose, worker_timeout: worker_timeout)
+            Mihari::App.run!(port: options["port"], host: options["host"], threads: options["threads"],
+              verbose: options["verbose"], worker_timeout: options["worker_timeout"])
           end
         end
       end

--- a/lib/mihari/entities/artifact.rb
+++ b/lib/mihari/entities/artifact.rb
@@ -12,11 +12,12 @@ module Mihari
       expose :data_type, documentation: { type: String, required: true }, as: :dataType
       expose :source, documentation: { type: String, required: true }
       expose :tags, documentation: { type: String, is_array: true }
-
-      expose :metadata, documentation: { type: Hash }
     end
 
     class Artifact < BaseArtifact
+      # NOTE: do not define metadata in BaseArtifact since metadata can be relatively big
+      expose :metadata, documentation: { type: Hash }
+
       expose :autonomous_system, using: Entities::AutonomousSystem,
         documentation: { type: Entities::AutonomousSystem, required: false }, as: :autonomousSystem
       expose :geolocation, using: Entities::Geolocation, documentation: { type: Entities::Geolocation, required: false }

--- a/lib/mihari/models/alert.rb
+++ b/lib/mihari/models/alert.rb
@@ -53,13 +53,8 @@ module Mihari
       def get_artifact_ids_by_filter(filter)
         artifact_ids = []
 
-        artifact = Artifact.includes(:autonomous_system, :dns_records, :reverse_dns_names)
-        artifact = artifact.where(data: filter.artifact_data) if filter.artifact_data
-        artifact = artifact.where(autonomous_system: { asn: filter.asn }) if filter.asn
-        artifact = artifact.where(dns_records: { value: filter.dns_record }) if filter.dns_record
-        artifact = artifact.where(reverse_dns_names: { name: filter.reverse_dns_name }) if filter.reverse_dns_name
-        # get artifact ids if there is any valid filter for artifact
-        if filter.valid_artifact_filters?
+        if filter.artifact_data
+          artifact = Artifact.where(data: filter.artifact_data)
           artifact_ids = artifact.pluck(:id)
           # set invalid ID if nothing is matched with the filters
           artifact_ids = [-1] if artifact_ids.empty?

--- a/lib/mihari/models/rule.rb
+++ b/lib/mihari/models/rule.rb
@@ -67,8 +67,7 @@ module Mihari
 
         relation = relation.where(alerts: { tags: { name: filter.tag_name } }) if filter.tag_name
 
-        relation = relation.where(title: filter.title) if filter.title
-
+        relation = relation.where("rules.title LIKE ?", "%#{filter.title}%") if filter.title
         relation = relation.where("rules.description LIKE ?", "%#{filter.description}%") if filter.description
 
         relation = relation.where("rules.created_at >= ?", filter.from_at) if filter.from_at

--- a/lib/mihari/structs/filters.rb
+++ b/lib/mihari/structs/filters.rb
@@ -10,13 +10,6 @@ module Mihari
           attribute? :tag_name, Types::String.optional
           attribute? :from_at, Types::DateTime.optional
           attribute? :to_at, Types::DateTime.optional
-          attribute? :asn, Types::Int.optional
-          attribute? :dns_record, Types::String.optional
-          attribute? :reverse_dns_name, Types::String.optional
-
-          def valid_artifact_filters?
-            !(artifact_data || asn || dns_record || reverse_dns_name).nil?
-          end
         end
 
         class SearchFilterWithPagination < SearchFilter
@@ -29,10 +22,7 @@ module Mihari
               from_at: from_at,
               rule_id: rule_id,
               tag_name: tag_name,
-              to_at: to_at,
-              asn: asn,
-              dns_record: dns_record,
-              reverse_dns_name: reverse_dns_name
+              to_at: to_at
             )
           end
         end

--- a/lib/mihari/structs/filters.rb
+++ b/lib/mihari/structs/filters.rb
@@ -6,10 +6,8 @@ module Mihari
       module Alert
         class SearchFilter < Dry::Struct
           attribute? :artifact_data, Types::String.optional
-          attribute? :description, Types::String.optional
           attribute? :rule_id, Types::String.optional
           attribute? :tag_name, Types::String.optional
-          attribute? :title, Types::String.optional
           attribute? :from_at, Types::DateTime.optional
           attribute? :to_at, Types::DateTime.optional
           attribute? :asn, Types::Int.optional
@@ -28,11 +26,9 @@ module Mihari
           def without_pagination
             SearchFilter.new(
               artifact_data: artifact_data,
-              description: description,
               from_at: from_at,
               rule_id: rule_id,
               tag_name: tag_name,
-              title: title,
               to_at: to_at,
               asn: asn,
               dns_record: dns_record,

--- a/lib/mihari/web/endpoints/alerts.rb
+++ b/lib/mihari/web/endpoints/alerts.rb
@@ -15,17 +15,11 @@ module Mihari
           optional :limit, type: Integer, default: 10
 
           optional :artifact, type: String
-          optional :description, type: String
           optional :rule_id, type: String
           optional :tag, type: String
-          optional :title, type: String
 
           optional :fromAt, type: DateTime
           optional :toAt, type: DateTime
-
-          optional :asn, type: Integer
-          optional :dnsRecord, type: String
-          optional :reverseDnsName, type: String
         end
         get "/" do
           filter = params.to_h.to_snake_keys

--- a/lib/mihari/web/endpoints/alerts.rb
+++ b/lib/mihari/web/endpoints/alerts.rb
@@ -11,7 +11,8 @@ module Mihari
           summary: "Search alerts"
         }
         params do
-          optional :page, type: Integer
+          optional :page, type: Integer, default: 1
+          optional :limit, type: Integer, default: 10
 
           optional :artifact, type: String
           optional :description, type: String
@@ -29,17 +30,9 @@ module Mihari
         get "/" do
           filter = params.to_h.to_snake_keys
 
-          # set page & limit
-          page = filter["page"] || 1
-          filter["page"] = page.to_i
-
-          limit = 10
-          filter["limit"] = 10
-
           # normalize keys
           filter["artifact_data"] = filter["artifact"]
           filter["tag_name"] = filter["tag"]
-
           # symbolize hash keys
           filter = filter.to_h.symbolize_keys
 
@@ -51,8 +44,8 @@ module Mihari
             {
               alerts: alerts,
               total: total,
-              current_page: page,
-              page_size: limit
+              current_page: filter[:page].to_i,
+              page_size: filter[:limit].to_i
             },
             with: Entities::AlertsWithPagination
           )

--- a/lib/mihari/web/endpoints/alerts.rb
+++ b/lib/mihari/web/endpoints/alerts.rb
@@ -36,9 +36,9 @@ module Mihari
           # symbolize hash keys
           filter = filter.to_h.symbolize_keys
 
-          search_filter_with_pagenation = Structs::Filters::Alert::SearchFilterWithPagination.new(**filter)
-          alerts = Mihari::Alert.search(search_filter_with_pagenation)
-          total = Mihari::Alert.count(search_filter_with_pagenation.without_pagination)
+          search_filter_with_pagination = Structs::Filters::Alert::SearchFilterWithPagination.new(**filter)
+          alerts = Mihari::Alert.search(search_filter_with_pagination)
+          total = Mihari::Alert.count(search_filter_with_pagination.without_pagination)
 
           present(
             {

--- a/lib/mihari/web/endpoints/rules.rb
+++ b/lib/mihari/web/endpoints/rules.rb
@@ -21,7 +21,8 @@ module Mihari
           summary: "Search rules"
         }
         params do
-          optional :page, type: Integer
+          optional :page, type: Integer, default: 1
+          optional :limit, type: Integer, default: 10
 
           optional :title, type: String
           optional :description, type: String
@@ -33,16 +34,8 @@ module Mihari
         get "/" do
           filter = params.to_h.to_snake_keys
 
-          # set page & limit
-          page = filter["page"] || 1
-          filter["page"] = page.to_i
-
-          limit = 10
-          filter["limit"] = 10
-
           # normalize keys
           filter["tag_name"] = filter["tag"]
-
           # symbolize hash keys
           filter = filter.to_h.symbolize_keys
 
@@ -53,8 +46,8 @@ module Mihari
           present(
             { rules: rules,
               total: total,
-              current_page: page,
-              page_size: limit },
+              current_page: filter[:page].to_i,
+              page_size: filter[:limit].to_i },
             with: Entities::RulesWithPagination
           )
         end

--- a/spec/models/alert_spec.rb
+++ b/spec/models/alert_spec.rb
@@ -30,21 +30,6 @@ RSpec.describe Mihari::Alert do
       alerts = described_class.search(Mihari::Structs::Filters::Alert::SearchFilterWithPagination.new(rule_id: "404"))
       expect(alerts.length).to eq(0)
     end
-
-    it do
-      alerts = described_class.search(Mihari::Structs::Filters::Alert::SearchFilterWithPagination.new(asn: asn))
-      expect(alerts.length).to eq(1)
-    end
-
-    it do
-      alerts = described_class.search(Mihari::Structs::Filters::Alert::SearchFilterWithPagination.new(reverse_dns_name: reverse_dns_name))
-      expect(alerts.length).to eq(1)
-    end
-
-    it do
-      alerts = described_class.search(Mihari::Structs::Filters::Alert::SearchFilterWithPagination.new(dns_record: dns_record))
-      expect(alerts.length).to eq(1)
-    end
   end
 
   describe ".count" do
@@ -66,21 +51,6 @@ RSpec.describe Mihari::Alert do
     it do
       count = described_class.count(Mihari::Structs::Filters::Alert::SearchFilter.new(rule_id: "404"))
       expect(count).to eq(0)
-    end
-
-    it do
-      count = described_class.count(Mihari::Structs::Filters::Alert::SearchFilter.new(asn: asn))
-      expect(count).to eq(1)
-    end
-
-    it do
-      count = described_class.count(Mihari::Structs::Filters::Alert::SearchFilter.new(reverse_dns_name: reverse_dns_name))
-      expect(count).to eq(1)
-    end
-
-    it do
-      count = described_class.count(Mihari::Structs::Filters::Alert::SearchFilter.new(dns_record: dns_record))
-      expect(count).to eq(1)
     end
   end
 end


### PR DESCRIPTION
Renew API endpoints spec

- Make `limit` for search customizable
- Remove `title`, `description`, `asn`, `dns_record` and `reverse_dns_name` filter from the alert search (to improve performance)
- Stop including artifact `metadata` in the alert search (same as the above)
- Allow LIKE search for `title` in the rule search