### PR TITLE
Upgrade to latest Mihari version and fix Censys errors

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:3.2.2-alpine3.18
 RUN apk --no-cache add git build-base ruby-dev sqlite-dev postgresql-dev mysql-client mysql-dev && \
   gem install pg mysql2
 
-ARG MIHARI_VERSION=5.2.2
+ARG MIHARI_VERSION=5.3.1
 
 RUN gem install mihari -v ${MIHARI_VERSION}
 


### PR DESCRIPTION
This fixes the issue I just created where the old Docker version causes unexpected Censys queries to hang.