### PR TITLE
Optimize Docker image size with optimized layering and cleanup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,12 @@
 FROM ruby:3.2.2-alpine3.18
 
-RUN apk --no-cache add git build-base ruby-dev postgresql-dev && \
-  gem install pg
-
 ARG MIHARI_VERSION=6.0.0
 
-RUN gem install mihari -v ${MIHARI_VERSION}
-
-RUN apk del --purge git build-base ruby-dev
+RUN apk --no-cache add git build-base ruby-dev postgresql-dev && \
+  gem install pg && \
+  gem install mihari -v ${MIHARI_VERSION} && \
+  apk del --purge git build-base ruby-dev && \
+  rm -rf /usr/local/bundle/cache/*
 
 ENTRYPOINT ["mihari"]
 


### PR DESCRIPTION
Streamlined Dockerfile by implementing best practices for a more compact image build.

Changes:
- Combined RUN commands into a single layer to reduce layer overhead and decrease image size.
- Executed package removal and cache cleanup in the same RUN command block as installations to prevent buildup of unnecessary data in the image layers.
- Achieved a reduction in image size from ~700MB to 604MB, ensuring more efficient storage use and faster deployment.

This approach ensures that intermediate build artifacts are not included in the final image, optimizing both build time and the resulting image size:
```
REPOSITORY          TAG               IMAGE ID       CREATED          SIZE
mihari              after             9df52386bb6f   30 minutes ago   604MB
mihari              before            11c7b0edbee5   37 minutes ago   700MB
```