### PR TITLE
fix: check Fofa response

### DIFF
--- a/lib/mihari/clients/fofa.rb
+++ b/lib/mihari/clients/fofa.rb
@@ -52,7 +52,10 @@ module Mihari
       def search(query, page:, size: PAGE_SIZE)
         qbase64 = Base64.urlsafe_encode64(query)
         params = { qbase64: qbase64, size: size, page: page, email: email, key: api_key }.compact
-        Structs::Fofa::Response.from_dynamic! get_json("/api/v1/search/all", params: params)
+        res = Structs::Fofa::Response.from_dynamic!(get_json("/api/v1/search/all", params: params))
+        raise ResponseError, res.errmsg if res.error
+
+        res
       end
 
       #

--- a/lib/mihari/structs/fofa.rb
+++ b/lib/mihari/structs/fofa.rb
@@ -8,6 +8,10 @@ module Mihari
         #   @return [Boolean]
         attribute :error, Types::Bool
 
+        # @!attribute [r] errmsg
+        #   @return [String, nil]
+        attribute? :errmsg, Types::String.optional
+
         # @!attribute [r] size
         #   @return [Integer, nil]
         attribute? :size, Types::Int.optional
@@ -35,6 +39,7 @@ module Mihari
           def from_dynamic!(d)
             new(
               error: d.fetch("error"),
+              errmsg: d["errmsg"],
               size: d["size"],
               page: d["page"],
               mode: d["mode"],


### PR DESCRIPTION
Check Fofa's response whether it has positive `error` or not to fix #917.

Fofa returns an error message in 200 status code. It's a reason behind #917.