### PR TITLE
feat: delete orphaned alert

### DIFF
--- a/frontend/src/components/alert/Alert.vue
+++ b/frontend/src/components/alert/Alert.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="box">
+  <div class="box" v-if="!isDeleted">
     <ErrorMessage
       class="block"
       :error="error"
@@ -25,7 +25,7 @@
       <tr>
         <th>Artifacts</th>
         <td>
-          <Artifacts :artifacts="alert.artifacts"></Artifacts>
+          <Artifacts :artifacts="alert.artifacts" @delete="onArtifactsDeleted"></Artifacts>
         </td>
       </tr>
       <tr v-if="alert.tags.length > 0">
@@ -66,6 +66,7 @@ export default defineComponent({
   },
   emits: ["delete"],
   setup(_, context) {
+    const isDeleted = ref(false)
     const error = ref<AxiosError>()
 
     const onSetError = (newError: AxiosError) => {
@@ -80,13 +81,19 @@ export default defineComponent({
       context.emit("delete")
     }
 
+    const onArtifactsDeleted = () => {
+      isDeleted.value = true
+    }
+
     return {
       onDelete,
       getLocalDatetime,
       getHumanizedRelativeTime,
       onSetError,
       onDisposeError,
-      error
+      error,
+      isDeleted,
+      onArtifactsDeleted
     }
   }
 })

--- a/frontend/src/components/alert/AlertDetail.vue
+++ b/frontend/src/components/alert/AlertDetail.vue
@@ -23,7 +23,7 @@
       <tr>
         <th>Artifacts</th>
         <td>
-          <Artifacts :artifacts="alert.artifacts"></Artifacts>
+          <Artifacts :artifacts="alert.artifacts" @delete="onArtifactsDeleted"></Artifacts>
         </td>
       </tr>
       <tr v-if="alert.tags.length > 0">
@@ -85,13 +85,16 @@ export default defineComponent({
       context.emit("delete")
     }
 
+    const onArtifactsDeleted = onDelete
+
     return {
       onDelete,
       getLocalDatetime,
       getHumanizedRelativeTime,
       onSetError,
       onDisposeError,
-      error
+      error,
+      onArtifactsDeleted
     }
   }
 })

--- a/frontend/src/components/artifact/ArtifactTag.vue
+++ b/frontend/src/components/artifact/ArtifactTag.vue
@@ -30,7 +30,8 @@ export default defineComponent({
       required: true
     }
   },
-  setup(props) {
+  emits: ["delete"],
+  setup(props, context) {
     const isDeleted = ref(false)
     const isDeleteButtonEnabled = ref(false)
 
@@ -42,6 +43,7 @@ export default defineComponent({
       if (confirmed) {
         await deleteArtifactTask.perform(props.artifact.id)
         isDeleted.value = true
+        context.emit("delete")
       }
     }
 

--- a/frontend/src/components/artifact/ArtifactTags.vue
+++ b/frontend/src/components/artifact/ArtifactTags.vue
@@ -4,12 +4,13 @@
       v-for="artifact in artifacts"
       :key="artifact.id"
       :artifact="artifact"
+      @delete="onDelete"
     ></ArtifactTag>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, type PropType } from "vue"
+import { defineComponent, type PropType, ref, watch } from "vue"
 
 import ArtifactTag from "@/components/artifact/ArtifactTag.vue"
 import type { Artifact } from "@/types"
@@ -24,6 +25,23 @@ export default defineComponent({
       type: Array as PropType<Artifact[]>,
       required: true
     }
+  },
+  emits: ["delete"],
+  setup(props, context) {
+    const count = ref(0)
+
+    const onDelete = () => {
+      count.value += 1
+    }
+
+    watch(count, () => {
+      // Emit "delete" when all the artifacts are deleted
+      if (count.value >= props.artifacts.length) {
+        context.emit("delete")
+      }
+    })
+
+    return { onDelete }
   }
 })
 </script>

--- a/lib/mihari/models/artifact.rb
+++ b/lib/mihari/models/artifact.rb
@@ -57,6 +57,14 @@ module Mihari
       # @return [String, nil]
       attr_accessor :rule_id
 
+      before_destroy do
+        @alert = alert
+      end
+
+      after_destroy do
+        @alert.destroy unless @alert.artifacts.any?
+      end
+
       #
       # Check uniqueness
       #

--- a/spec/models/artifact_spec.rb
+++ b/spec/models/artifact_spec.rb
@@ -267,4 +267,18 @@ RSpec.describe Mihari::Models::Artifact, :vcr do
       expect(count).to eq(0)
     end
   end
+
+  describe ".after_destroy" do
+    let(:artifact) { FactoryBot.create(:artifact) }
+    let(:alert) { artifact.alert }
+
+    it do
+      expect(Mihari::Models::Alert.exists?(alert.id)).to eq(true)
+    end
+
+    it do
+      artifact.destroy
+      expect(Mihari::Models::Alert.exists?(alert.id)).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
Automatically destroy an orphan alert (an alert does not have any artifacts) by using before/after destroy callbacks.