### PR TITLE
refactor: split parallel into analyzer_parallelism & emitter_parallelism

### DIFF
--- a/docs/analyzers/index.md
+++ b/docs/analyzers/index.md
@@ -97,7 +97,7 @@ queries:
 
 ### Parallel
 
-`parallel` (`bool`) controls whether to allow parallel execution or not. Optional. Defaults to `false`. Configurable via `PARALLEL` environment variable.
+`parallel` (`bool`) controls whether to allow parallel execution or not. Optional. Defaults to `false`. Configurable via `ANALYZER_PARALLELISM` environment variable.
 
 ### Pagination Interval
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,10 +44,11 @@ Alternatively you can set values through `.env` file. Values in `.env` file will
 
 | Environment Variable      | Type    | Description                               | Default |
 | ------------------------- | ------- | ----------------------------------------- | ------- |
+| ANALYZER_PARALLELISM      | Boolean | Whether to run analyzers in parallel      | `false` |
+| EMITTER_PARALLELISM       | Boolean | Whether to run emitters in parallel       | `true`  |
 | IGNORE_ERROR              | Boolean | Whether to ignore error while querying    | `false` |
 | PAGINATION_INTERVAL       | Integer | Pagination interval                       | `0`     |
 | PAGINATION_LIMIT          | Integer | Pagination limit                          | `100`   |
-| PARALLEL                  | Boolean | Whether to run queries in parallel        | `false` |
 | RETRY_EXPONENTIAL_BACKOFF | Boolean | Whether to use retry exponential back off | `true`  |
 | RETRY_INTERVAL            | Integer | Retry interval                            | `5`     |
 | RETRY_TIMES               | Integer | Retry times                               | `3`     |

--- a/docs/emitters/index.md
+++ b/docs/emitters/index.md
@@ -38,4 +38,4 @@ options:
 
 ### Parallel
 
-`parallel` (`bool`) controls whether to allow parallel execution or not. Optional. Defaults to `false`. Configurable via `PARALLEL` environment variable.
+`parallel` (`bool`) controls whether to allow parallel execution or not. Optional. Defaults to `true`. Configurable via `EMITTER_PARALLELISM` environment variable.

--- a/lib/mihari/analyzers/base.rb
+++ b/lib/mihari/analyzers/base.rb
@@ -44,7 +44,7 @@ module Mihari
       # @return [Boolean]
       #
       def parallel?
-        options[:parallel] || Mihari.config.parallel
+        options[:parallel] || Mihari.config.analyzer_parallelism
       end
 
       # @return [Array<String>, Array<Mihari::Models::Artifact>]

--- a/lib/mihari/config.rb
+++ b/lib/mihari/config.rb
@@ -42,7 +42,8 @@ module Mihari
       ignore_error: false,
       pagination_interval: 0,
       pagination_limit: 100,
-      parallel: false,
+      analyzer_parallelism: false,
+      emitter_parallelism: true,
       retry_exponential_backoff: true,
       retry_interval: 5,
       retry_times: 3,
@@ -146,7 +147,10 @@ module Mihari
     # @!attribute [r] pagination_limit
     #   @return [Integer]
 
-    # @!attribute [r] parallel
+    # @!attribute [r] analyzer_parallelism
+    #   @return [Boolean]
+
+    # @!attribute [r] emitter_parallelism
     #   @return [Boolean]
 
     # @!attribute [r] ignore_error

--- a/lib/mihari/emitters/base.rb
+++ b/lib/mihari/emitters/base.rb
@@ -23,7 +23,7 @@ module Mihari
       # @return [Boolean]
       #
       def parallel?
-        options[:parallel] || Mihari.config.parallel
+        options[:parallel] || Mihari.config.emitter_parallelism
       end
 
       # A target to emit the data


### PR DESCRIPTION
Split a role of `PARALLEL` environment.

It can control analyzer & emitter parallelism. But it will be better to control them separately.

- `ANALYZER_PRALLELISM` controls analyzer parallelism (= default `parallel` value for analyzers)
- `EMITTER_PRALLELISM` controls emitter parallelism (= default `parallel` value for emitters)