### PR TITLE
Update webhook documentation for API key usage

### DIFF
--- a/docs/emitters/webhook.md
+++ b/docs/emitters/webhook.md
@@ -43,7 +43,7 @@ You can use the following attributes inside a Jbuilder template.
 - emitter: webhook
   url: https://threatfox-api.abuse.ch/api/v1/
   headers:
-    api-key: YOUR_API_KEY
+    auth-key: YOUR_AUTH_KEY
   template: /path/to/threatfox.json.jbuilder
 ```
 


### PR DESCRIPTION
Update the webhook documentation to replace the example API key with the correct `auth-key` terminology.