### PR TITLE
fix: skip non-host hits in Censys V3 struct parsing

### DIFF
--- a/lib/mihari/structs/censys.rb
+++ b/lib/mihari/structs/censys.rb
@@ -291,6 +291,7 @@ module Mihari
           class << self
             def from_dynamic!(d)
               res = d.dig("host_v1", "resource") || {}
+              return nil if res["ip"].nil?
               new(
                 ip: res["ip"],
                 autonomous_system: res["autonomous_system"],
@@ -313,7 +314,7 @@ module Mihari
           class << self
             def from_dynamic!(d)
               new(
-                hits: (d["hits"] || []).map { |x| Hit.from_dynamic!(x) },
+                hits: (d["hits"] || []).filter_map { |x| Hit.from_dynamic!(x) },
                 next_page_token: d["next_page_token"]
               )
             end


### PR DESCRIPTION
## Problem
The Censys V3 global search endpoint (`/v3/global/search/query`) returns mixed result types — hosts, web properties, and certificates. When a non-host hit is returned, `d.dig("host_v1", "resource")` returns `{}`, so `res["ip"]` is `nil`, causing:

> `[Mihari::Structs::Censys::V3::Hit.new] nil (NilClass) has invalid type for :ip violates constraints (type?(String, nil) failed)`

## Fix
Two minimal changes to `lib/mihari/structs/censys.rb`:

1. `V3::Hit.from_dynamic!` — return `nil` early when `ip` is absent (non-host hit)
2. `V3::Result.from_dynamic!` — use `filter_map` instead of `map` to silently drop those `nil` hits

Non-host results are discarded; only valid host artifacts are returned.

Closes #1180